### PR TITLE
Better method to get audio Element + CSS tweaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,8 +40,13 @@ SOFTWARE.
         <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Noto+Sans">
         <link rel="stylesheet" href="styles/stylesheet.css">
     </head>
-    <body onload="playAudio()">
-        <audio src="Media/Je%20Moeder.ogg" loop ontimeupdate="cancelAlert()">
+    <body>
+        <noscript>
+            <div>
+                <p>Sorry, this website needs JavaScript to deliver the full dankness.</p>
+            </div>
+        </noscript>
+        <audio src="Media/Je%20Moeder.ogg" loop>
             <div>
                 <p>Sorry, your browser doesn't support HTML5 audio playing.</p>
             </div>

--- a/scripts/check-autoplay.js
+++ b/scripts/check-autoplay.js
@@ -28,8 +28,7 @@
 /**
  * A boolean value to determine if alert dialog should be shown.
  * Only used when the fallback method {@link #prepareAlert} is called.
- * If audio starts playing automatically, {@link #cancelAlert} is called,
- * setting this value to "false".
+ * If audio starts playing automatically, this value is set to "false".
  * 
  * @default true
  * @type {boolean}
@@ -61,15 +60,6 @@ const MESSAGE = "Your internet browser doesn't seem to support or allow audio au
 window.onerror = (message, source, lineNumber, columnNumber, error) => console.log(`An error occured, please report this at https://github.com/VanishedApps/dank/issues/new .\n\nFull details, copy and paste into issue description:\n\n${error.toString()}`);
 
 /**
- * Cancel the alert by setting {@link #shouldAlert} to "false",
- * after being triggered by the "ontimeupdate" event.
- * @listens ontimeupdate
- */
-function cancelAlert() {
-    shouldAlert = false;
-}
-
-/**
  * Attempt to play audio when the page is loaded.
  * If autoplay is disabled or unsupported, an alert dialog is shown.
  * 
@@ -77,7 +67,7 @@ function cancelAlert() {
  * fallback method {@link #prepareAlert} is used.
  * @listens onload
  */
-function playAudio() {
+document.body.onload = () => {
     // Load audio element
     initializeAudioElement();
     const promise = audioElement.play();
@@ -97,16 +87,15 @@ function playAudio() {
  * @throws {Error} Throws an Error if the correct audio element can't be found.
  */
 function initializeAudioElement() {
-    // Get all elements with "audio" tag from DOM as an array
-    const audioElements = document.getElementsByTagName("audio");
-    // Check if there is exactly 1 audio element
-    if (audioElements.length !== 1) {
-        // None or more than one are found
+    // Get element with "audio" tag from DOM
+    audioElement = document.querySelector("audio");
+    // Check if the audio element exists
+    if (audioElement === null) {
+        // None is found
         throw new Error("Can not find the correct element with tag name \"audio\"!");
     }
-    // Initialize the audioElement object
-    // Index is 0 as there is only one audio element
-    audioElement = audioElements[0];
+    // Add event listener
+    audioElement.ontimeupdate = () => shouldAlert = false;
 }
 
 /**
@@ -150,13 +139,13 @@ function showAlert(reason) {
 }
 
 /**
- * Remove event listeners for "ontimeupdate" event
+ * Remove event listener for "ontimeupdate" event
  * from the audio element to free up system resource.
  * If {@link #audioElement} is never initialized successfully,
  * this function does nothing.
  */
 function removeAttrForAudioElement() {
-    if (audioElement !== undefined) {
+    if (audioElement !== null) {
         audioElement.removeAttribute("ontimeupdate");
     }
 }

--- a/scripts/check-autoplay.js
+++ b/scripts/check-autoplay.js
@@ -58,9 +58,7 @@ const MESSAGE = "Your internet browser doesn't seem to support or allow audio au
  * @type {function}
  * @listens onerror
  */
-window.onerror = function(message, source, lineNumber, columnNumber, error) {
-    console.log(`An error occured, please report this at https://github.com/VanishedApps/dank/issues/new .\n\nFull details, copy and paste into issue description:\n\n${error.stack}`);
-}
+window.onerror = (message, source, lineNumber, columnNumber, error) => console.log(`An error occured, please report this at https://github.com/VanishedApps/dank/issues/new .\n\nFull details, copy and paste into issue description:\n\n${error.stack}`);
 
 /**
  * Cancel the alert by setting {@link #shouldAlert} to "false",
@@ -85,14 +83,8 @@ function playAudio() {
     const promise = audioElement.play();
     // Check if browser returns a Promise
     if (promise !== undefined) {
-        // Check if audio can start playing
-        promise.then(
-            // Audio can start playing, do nothing
-            function() {},
-            // Audio can't start playing, show the alert dialog
-            function(reason) {
-                showAlert(reason.toString());
-        });
+        // Check if audio can start playing, if not then show the alert dialog
+        promise.catch(reason => showAlert(reason.toString()));
     } else {
         // Browser does not return a Promise, use hacky fallback method
         // to determine if audio is playing
@@ -130,7 +122,7 @@ function initializeAudioElement() {
  * @listens oncanplaythrough
  */
 function prepareAlert() {
-    setTimeout(function() {
+    setTimeout(() => {
         // Check if audio is already playing
         if (shouldAlert) {
             // No audio is playing, show the alert dialog
@@ -164,7 +156,7 @@ function showAlert(reason) {
  * this function does nothing.
  */
 function removeAttrForAudioElement() {
-    if (typeof audioElement !== "undefined") {
+    if (audioElement !== undefined) {
         audioElement.removeAttribute("ontimeupdate");
     }
 }

--- a/scripts/check-autoplay.js
+++ b/scripts/check-autoplay.js
@@ -58,7 +58,7 @@ const MESSAGE = "Your internet browser doesn't seem to support or allow audio au
  * @type {function}
  * @listens onerror
  */
-window.onerror = (message, source, lineNumber, columnNumber, error) => console.log(`An error occured, please report this at https://github.com/VanishedApps/dank/issues/new .\n\nFull details, copy and paste into issue description:\n\n${error.stack}`);
+window.onerror = (message, source, lineNumber, columnNumber, error) => console.log(`An error occured, please report this at https://github.com/VanishedApps/dank/issues/new .\n\nFull details, copy and paste into issue description:\n\n${error.toString()}`);
 
 /**
  * Cancel the alert by setting {@link #shouldAlert} to "false",
@@ -142,7 +142,7 @@ function showAlert(reason) {
     if (typeof reason !== "string") {
         throw new TypeError("Reason must be a string!");
     }
-    var alertMessage = MESSAGE;
+    let alertMessage = MESSAGE;
     if (reason !== undefined && reason !== null) {
         alertMessage += `\n\nReason:\n${reason}`;
     }

--- a/secret.html
+++ b/secret.html
@@ -44,7 +44,7 @@ SOFTWARE.
         <div>
             <p><strong>VanishedApps</strong><br>:^)</p>
             <form title="Click here to feel dank again" action="index.html" method="GET">
-                <input type="submit" value="Click here to feel dank again">
+                <button type="submit">Click here to feel dank again</button>
             </form>
         </div>
     </body>

--- a/styles/stylesheet.css
+++ b/styles/stylesheet.css
@@ -39,7 +39,7 @@ body {
     width: 100%;
     height: 100%;
     background: url("../Media/Je%20Moeder.gif") center;
-    background-size: 33.3%;
+    background-size: calc(100% / 3);
 }
 
 div {

--- a/styles/stylesheet.css
+++ b/styles/stylesheet.css
@@ -51,7 +51,7 @@ p {
     line-height: 1.5;
 }
 
-input {
+button {
     margin-top: 15px;
     padding: 10px;
     font-size: 1rem;
@@ -63,7 +63,7 @@ input {
     transition: background-color 0.3s ease-in-out;
 }
 
-input:hover,
-input:active {
+button:hover,
+button:active {
     background-color: #b63d1e;
 }


### PR DESCRIPTION
- Used arrow function syntax
- Replaced then() with catch() for Promise, more intuitive when read ( catch() still calls then() internally )
- Replaced non-standard error.stack with error.toString()
- Replaced var with let where sensible
- Display a banner at the top, informing the user that JavaScript is required, if JavaScript is turned off or not supported
- Moved event related stuff into JS file
- Removed cancelAlert() function, it's now put directly in initializeAudioElement()
- Used querySelector() to simplify the process of getting audio element
- Changed input to button
@VanishedApps :)